### PR TITLE
Added support for SmolVLM2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-accelerate==1.6.0
+accelerate==1.10.0
 aiohappyeyeballs==2.6.1
 aiohttp==3.11.18
 aiosignal==1.3.2
@@ -56,7 +56,7 @@ opencv-python==4.11.0.86
 packaging==25.0
 pandas==2.2.3
 parso==0.8.4
-peft==0.15.2
+peft==0.17.1
 pexpect==4.9.0
 pickleshare==0.7.5
 pillow==11.0.0
@@ -80,7 +80,7 @@ pyzmq==26.4.0
 regex==2024.11.6
 requests==2.32.3
 rich==14.0.0
-safetensors==0.5.3
+safetensors==0.6.2
 sentry-sdk==2.27.0
 setproctitle==1.3.5
 setuptools==79.0.1
@@ -96,7 +96,7 @@ torchvision==0.21.0+cu124
 tornado==6.4.2
 tqdm==4.67.1
 traitlets==5.14.3
-transformers==4.51.3
+transformers==4.55.1
 triton==3.2.0
 trl==0.17.0
 typing_extensions==4.13.2

--- a/src/train/params.py
+++ b/src/train/params.py
@@ -64,3 +64,4 @@ class DataArguments:
     lazy_preprocess: bool = False
     image_folder: Optional[str] = field(default=None)
     max_num_frames: int = 10
+    strict_image_validation: bool = False

--- a/src/train/train_sft.py
+++ b/src/train/train_sft.py
@@ -2,7 +2,7 @@ import os
 import torch
 from peft import LoraConfig, get_peft_model
 import ast
-from transformers import AutoProcessor, BitsAndBytesConfig, AutoModelForVision2Seq, HfArgumentParser
+from transformers import AutoProcessor, BitsAndBytesConfig, HfArgumentParser, AutoModelForImageTextToText
 from train.trainer import SmolVLMTrainer
 from train.data import make_supervised_data_module
 from train.params import DataArguments, ModelArguments, TrainingArguments
@@ -150,7 +150,7 @@ def train():
             )
         ))
 
-    model = AutoModelForVision2Seq.from_pretrained(
+    model = AutoModelForImageTextToText.from_pretrained(
         model_args.model_id,
         torch_dtype=compute_dtype,
         _attn_implementation="flash_attention_2" if not training_args.disable_flash_attn2 else "eager", 

--- a/src/train/trainer.py
+++ b/src/train/trainer.py
@@ -6,12 +6,14 @@ from transformers import Trainer
 from transformers.trainer import (
     is_sagemaker_mp_enabled,
     get_parameter_names,
-    ALL_LAYERNORM_LAYERS,
     TRAINER_STATE_NAME,
     PREFIX_CHECKPOINT_DIR,
     logger,
     ExportableState,
     SaveStrategy
+)
+from transformers.pytorch_utils import (
+    ALL_LAYERNORM_LAYERS
 )
 import safetensors
 from peft import PeftModel


### PR DESCRIPTION
This PR adds support for SmolVLM2 finetuning. 
It doesn't break the finetuning for SmolVLM. 

High-Level changes

- Changed the base class for loading the model.
- Import errors
- Updated package versions
- Data argument for strict_image_validation

